### PR TITLE
improve dev performance on lists

### DIFF
--- a/univariate.ijs
+++ b/univariate.ijs
@@ -32,7 +32,9 @@ geomean=: mean &.: ^.           NB. geometric mean
 harmean=: mean &.: %            NB. harmonic mean
 commonmean=: [: {. (%:@*/ , -:@+/) ^: _
 
-dev=: -"_1 _ mean         NB. deviation from mean
+dev1=: - mean
+devn=: -"_1 _ mean
+dev=: dev1`devn@.(1<#@$)  NB. deviation from mean
 ssdev=: +/ @: *: @ dev    NB. sum of squared deviations
 var=: ssdev % <:@#        NB. sample variance
 stddev=: %: @ var         NB. sample standard deviation

--- a/univariate.ijs
+++ b/univariate.ijs
@@ -32,12 +32,10 @@ geomean=: mean &.: ^.           NB. geometric mean
 harmean=: mean &.: %            NB. harmonic mean
 commonmean=: [: {. (%:@*/ , -:@+/) ^: _
 
-dev1=: - mean
-devn=: -"_1 _ mean
-dev=: dev1`devn@.(1<#@$)  NB. deviation from mean
-ssdev=: +/ @: *: @ dev    NB. sum of squared deviations
-var=: ssdev % <:@#        NB. sample variance
-stddev=: %: @ var         NB. sample standard deviation
+dev=: (- mean)`(-"_1 _ mean)@.(1<#@$)  NB. deviation from mean
+ssdev=: +/ @: *: @ dev                 NB. sum of squared deviations
+var=: ssdev % <:@#                     NB. sample variance
+stddev=: %: @ var                      NB. sample standard deviation
 
 NB. "p" suffix = population definitions
 varp=: ssdev % #         NB. population variance


### PR DESCRIPTION
I noticed that `dev` is slower than need be for rank 1 arrays.
```j
   devn NB. current
-"_1 _ mean
   dev NB. proposed
dev1`devn@.(1 < #@$)
   (devn -: dev) x =: ? 1000000 $ 0
1
   10 (6!:2) 'devn x'
0.150482
   10 (6!:2) 'dev x'
0.0022252
```
If this is in bad taste, please discard!
